### PR TITLE
add custom error type

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
-use crate::data_type::*;
+use crate::{data_type::*, error::Error};
 use reqwest::header;
-use std::{error::Error, fmt::Debug};
+use std::fmt::Debug;
 use strum_macros::EnumString;
 
 /// All methods contain an `Option<String>` to provide an alternate api key to use if it differs from the default
@@ -42,10 +42,7 @@ impl OpenShockAPI {
     }
 
     /// Gets user info from the provided API key, the default key from the instance is used if `None` is provided
-    pub async fn get_user_info(
-        &self,
-        api_key: Option<String>,
-    ) -> Result<SelfResponse, Box<dyn Error>> {
+    pub async fn get_user_info(&self, api_key: Option<String>) -> Result<SelfResponse, Error> {
         let resp = self
             .client
             .get(format!("{}/1/users/self", self.base_url))
@@ -65,7 +62,7 @@ impl OpenShockAPI {
         &self,
         source: ListShockerSource,
         api_key: Option<String>,
-    ) -> Result<Vec<ListShockersResponse>, Box<dyn Error>> {
+    ) -> Result<Vec<ListShockersResponse>, Error> {
         let resp = self
             .client
             .get(format!("{}/1/shockers/{:?}", self.base_url, source))
@@ -88,7 +85,7 @@ impl OpenShockAPI {
         intensity: u8,
         duration: u16,
         api_key: Option<String>,
-    ) -> Result<String, Box<dyn Error>> {
+    ) -> Result<String, Error> {
         match intensity {
             1..=100 => {}
             _ => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,36 @@
+/// Error type for functions in this crate
+#[derive(Debug)]
+pub enum Error {
+    Reqwest(reqwest::Error),
+    Serde(serde_json::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Reqwest(value)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Serde(value)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Reqwest(e) => e.fmt(f),
+            Self::Serde(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Reqwest(e) => e.source(),
+            Self::Serde(e) => e.source(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,4 @@
 
 pub mod api;
 pub mod data_type;
+pub mod error;


### PR DESCRIPTION
this adds a very basic custom error type returned by the functions in `crate::api::OpenShockAPI`. that way, trait bounds like `Send` and `Sync` can be derived automatically (which isn't possible with the `Box<dyn Error>`) and it's much easier to correctly handle the errors when using this crate.