### PR TITLE
add user-agent header and set application name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,12 @@
 /// Error type for functions in this crate
 #[derive(Debug)]
 pub enum Error {
+    /// error propagated from reqwest
     Reqwest(reqwest::Error),
+    /// error propagated from serde
     Serde(serde_json::Error),
+    /// no API token was provided to the API interface
+    MissingApiToken,
 }
 
 impl From<reqwest::Error> for Error {
@@ -22,6 +26,7 @@ impl std::fmt::Display for Error {
         match self {
             Self::Reqwest(e) => e.fmt(f),
             Self::Serde(e) => e.fmt(f),
+            Self::MissingApiToken => write!(f, "no API token was provided"),
         }
     }
 }
@@ -31,6 +36,7 @@ impl std::error::Error for Error {
         match self {
             Self::Reqwest(e) => e.source(),
             Self::Serde(e) => e.source(),
+            Self::MissingApiToken => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Serde(serde_json::Error),
     /// no API token was provided to the API interface
     MissingApiToken,
+    /// invalid header value when building the API interface
+    InvalidHeaderValue(reqwest::header::InvalidHeaderValue),
 }
 
 impl From<reqwest::Error> for Error {
@@ -27,6 +29,7 @@ impl std::fmt::Display for Error {
             Self::Reqwest(e) => e.fmt(f),
             Self::Serde(e) => e.fmt(f),
             Self::MissingApiToken => write!(f, "no API token was provided"),
+            Self::InvalidHeaderValue(e) => write!(f, "invalid header value for user agent: {}", e),
         }
     }
 }
@@ -37,6 +40,7 @@ impl std::error::Error for Error {
             Self::Reqwest(e) => e.source(),
             Self::Serde(e) => e.source(),
             Self::MissingApiToken => None,
+            Self::InvalidHeaderValue(e) => e.source(),
         }
     }
 }


### PR DESCRIPTION
this pr first adds a builder pattern to `OpenShockAPI` so `OpenShockAPI::new` doesn't need to have more optional arguments added and becomes unwieldy.
the second commit then adds an option to configure the application name/version in the builder. this information is used in the user agent (if configured) similarly to what the official C# API bindings do. the application name is also passed as `custom_name` in `post_control` so the correct application name shows up the the logs on the OpenShock dashboard.

the introduction of this builder pattern might be a bit too much? feel free to give feedback!