### PR TITLE
Add more derives to enum types

### DIFF
--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -24,7 +24,7 @@ pub struct ShockerResponse {
     pub model: ShockerModel,
 }
 
-#[derive(EnumString, Serialize, Deserialize, Debug)]
+#[derive(EnumString, Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ShockerModel {
     CaiXianlin,
     PetTrainer,
@@ -38,7 +38,7 @@ pub struct BaseResponse<T> {
     pub data: Option<T>,
 }
 
-#[derive(EnumString, Serialize, Deserialize, Debug)]
+#[derive(EnumString, Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ControlType {
     Stop,
     Shock,
@@ -78,7 +78,7 @@ pub struct SelfResponse {
     pub rank: RankType,
 }
 
-#[derive(EnumString, Serialize, Deserialize, Debug)]
+#[derive(EnumString, Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum RankType {
     User,
     Support,


### PR DESCRIPTION
> just started learning rust

It's generally a good idea to add a few standard derives like these to enums. It makes working with them a lot easier. Arguably you could also add `Hash`, but I don't need it for my purposes.